### PR TITLE
Bugfix/installer without admin

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -24,7 +24,6 @@
         "target": "nsis",
         "arch": [
           "x64",
-          "ia32",
           "arm64"
         ]
       }
@@ -34,9 +33,8 @@
   },
   "nsis": {
     "oneClick": false,
-    "perMachine": false,
+    "perMachine": true,
     "allowToChangeInstallationDirectory": true,
-    "createStartMenuShortcut": true,
     "deleteAppDataOnUninstall": false
   },
   "linux": {

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -23,18 +23,8 @@
       {
         "target": "nsis",
         "arch": [
-          "x64"
-        ]
-      },
-      {
-        "target": "nsis",
-        "arch": [
-          "ia32"
-        ]
-      },
-      {
-        "target": "nsis",
-        "arch": [
+          "x64",
+          "ia32",
           "arm64"
         ]
       }


### PR DESCRIPTION
Installer hangs until app exits, maybe because it needs admin privs? Not sure why, but trying to see if installing without admin fixes it.