### PR TITLE
Upgrade @miniben90/x-win to lower glibc dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.633.0",
-        "@miniben90/x-win": "^1.10.2",
+        "@miniben90/x-win": "^2.1.0",
         "@radix-ui/react-avatar": "^1.1.0",
         "@radix-ui/react-checkbox": "^1.1.1",
         "@radix-ui/react-label": "^2.1.0",
@@ -2375,30 +2375,32 @@
       }
     },
     "node_modules/@miniben90/x-win": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/@miniben90/x-win/-/x-win-1.10.3.tgz",
-      "integrity": "sha512-LeR2VvJ4DMbiNBC9yKU0uHd9OnnKceVkzdk2O4YGJZDSW88CtpNAN1ea1TTS9OjvIInj/TQf+ObvMdPfQG5WOg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@miniben90/x-win/-/x-win-2.1.0.tgz",
+      "integrity": "sha512-DlXM8lLGVaD3iWX2zoi77FHqoFypjYp/3CdramcWErwkIpkq6f8ruaoqWFhIcOv0DnlkxyO5kshUwS8PeMlXcA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 14"
       },
       "optionalDependencies": {
-        "@miniben90/x-win-darwin-arm64": "1.10.3",
-        "@miniben90/x-win-darwin-universal": "1.10.3",
-        "@miniben90/x-win-darwin-x64": "1.10.3",
-        "@miniben90/x-win-linux-x64-gnu": "1.10.3",
-        "@miniben90/x-win-linux-x64-musl": "1.10.3",
-        "@miniben90/x-win-win32-arm64-msvc": "1.10.3",
-        "@miniben90/x-win-win32-ia32-msvc": "1.10.3",
-        "@miniben90/x-win-win32-x64-msvc": "1.10.3"
+        "@miniben90/x-win-darwin-arm64": "2.1.0",
+        "@miniben90/x-win-darwin-universal": "2.1.0",
+        "@miniben90/x-win-darwin-x64": "2.1.0",
+        "@miniben90/x-win-linux-x64-gnu": "2.1.0",
+        "@miniben90/x-win-linux-x64-musl": "2.1.0",
+        "@miniben90/x-win-win32-arm64-msvc": "2.1.0",
+        "@miniben90/x-win-win32-ia32-msvc": "2.1.0",
+        "@miniben90/x-win-win32-x64-msvc": "2.1.0"
       }
     },
     "node_modules/@miniben90/x-win-darwin-arm64": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/@miniben90/x-win-darwin-arm64/-/x-win-darwin-arm64-1.10.3.tgz",
-      "integrity": "sha512-L0iaj42g+NxkBB2Ls1utJgBWO12YP0hlRBBvH9YiPBpDMHDtfD35mGDRRhNoZ/q6HpEj7JcNEPC18zL4ykyuzQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@miniben90/x-win-darwin-arm64/-/x-win-darwin-arm64-2.1.0.tgz",
+      "integrity": "sha512-ZYi6sa32vT3flVtPqYhWunbJTHiNXbObYXUhucih/HKul2VI05F7VB9W55aFFXhgS5H4AcuhAtBBh5AqNqQYMA==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -2408,9 +2410,10 @@
       }
     },
     "node_modules/@miniben90/x-win-darwin-universal": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/@miniben90/x-win-darwin-universal/-/x-win-darwin-universal-1.10.3.tgz",
-      "integrity": "sha512-AzyY1RdBr2abrqXh800Y+49tba05bcjLdgLRXX7H/xwH671+C1f4k84cdkdP5Y7tu9N5ULbPnChbSnrsgltQGg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@miniben90/x-win-darwin-universal/-/x-win-darwin-universal-2.1.0.tgz",
+      "integrity": "sha512-VpTZGyTrC+NzUYf/FkjapvE8WYU0F1D8oSIBqRI8aCtXotWKyUJZWbVWVMZXq1Mu1bxij7RJJrdfqFJ18H4Frg==",
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -2420,12 +2423,13 @@
       }
     },
     "node_modules/@miniben90/x-win-darwin-x64": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/@miniben90/x-win-darwin-x64/-/x-win-darwin-x64-1.10.3.tgz",
-      "integrity": "sha512-5kW2sGBzKzqCSIkSOtfnOEBpXKbxTwhCcqKAyXvAlEk2hn5olGKl9ENzgZctv0iK5qrWpVVxBANo5E0e3zHPLQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@miniben90/x-win-darwin-x64/-/x-win-darwin-x64-2.1.0.tgz",
+      "integrity": "sha512-SFnZ8IOPtbAXYV20AFMDwNqEpbv4jzc7hOb7kWIKm1gpLi2RNhn292rK+m6vF1xxUlUZomC3xsZNoEmqq5Dbxw==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -2435,12 +2439,13 @@
       }
     },
     "node_modules/@miniben90/x-win-linux-x64-gnu": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/@miniben90/x-win-linux-x64-gnu/-/x-win-linux-x64-gnu-1.10.3.tgz",
-      "integrity": "sha512-3/VOB18SQaLYDbErtLgGHAzteH8pvAqyEw1F/b+leII1m0njA27tsxEel276RbM9p+A+KBPW2yLfqrGJnpllPQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@miniben90/x-win-linux-x64-gnu/-/x-win-linux-x64-gnu-2.1.0.tgz",
+      "integrity": "sha512-+Bv1MArKwm3yqibNKywuQ8/FWx9Ic+rIwle4A1NfcqrLterZTv798lyDmCwwrcKtB6hRwIQEGOrsG2EK3Lek2w==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2450,12 +2455,13 @@
       }
     },
     "node_modules/@miniben90/x-win-linux-x64-musl": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/@miniben90/x-win-linux-x64-musl/-/x-win-linux-x64-musl-1.10.3.tgz",
-      "integrity": "sha512-ErV8RvQ9CC5wxffR78thGtEyD43l4bm++D16ANoAlDJ3HF2K/bM8afzf9fK4nMlnAaxMGd96eetcJGUh1G0Mjw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@miniben90/x-win-linux-x64-musl/-/x-win-linux-x64-musl-2.1.0.tgz",
+      "integrity": "sha512-0isJj6y3U1bF242eP/5O28Dkdy6IuQfuIXCwkF4obpLQ8bEblQGJSWR/n4BtLJrbll3rrno29ePkQLGGEibWrA==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2465,12 +2471,13 @@
       }
     },
     "node_modules/@miniben90/x-win-win32-arm64-msvc": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/@miniben90/x-win-win32-arm64-msvc/-/x-win-win32-arm64-msvc-1.10.3.tgz",
-      "integrity": "sha512-83huvCuuSgPffE/XalWxDsPtPwBtJO29BxsHEzMXZG98kakaKMvMZrbDxVxTXDvKmEuGpDjhtSKjd37PfGtUeQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@miniben90/x-win-win32-arm64-msvc/-/x-win-win32-arm64-msvc-2.1.0.tgz",
+      "integrity": "sha512-SpS04FOS+1vVNA3/xPgP1eEc+hstzFsCndJ7qNZ2pgI4LZtveDiZqpyMDyX2pSVjkSKn+ulaw2OxjfSmI2VYAw==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -2480,12 +2487,13 @@
       }
     },
     "node_modules/@miniben90/x-win-win32-ia32-msvc": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/@miniben90/x-win-win32-ia32-msvc/-/x-win-win32-ia32-msvc-1.10.3.tgz",
-      "integrity": "sha512-HXlgPUeCllmPWm0/gq+Z2Ji2RyGySXkrjrJ4iPU1zHrs0s3k3BXnAduCH0fQm9T/8cXYubJyYE9ux/jaJ34xiw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@miniben90/x-win-win32-ia32-msvc/-/x-win-win32-ia32-msvc-2.1.0.tgz",
+      "integrity": "sha512-dhVX7SKXknqGzGQrgqq9uaxIz2ViG8Tm7TLbeVuZC/yRhDFnxW9PwrTEUx0iTOazwR8uOjFZddugHEuFPJhTEA==",
       "cpu": [
         "ia32"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -2495,12 +2503,13 @@
       }
     },
     "node_modules/@miniben90/x-win-win32-x64-msvc": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/@miniben90/x-win-win32-x64-msvc/-/x-win-win32-x64-msvc-1.10.3.tgz",
-      "integrity": "sha512-QTFSl47A+VeqhaEZw0vBErGVsFhu0OcujAyAYkzJp5tRI4W9JUNtnYADBRqmAQDxDlb26aaaGQyPHvfXMqRCKQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@miniben90/x-win-win32-x64-msvc/-/x-win-win32-x64-msvc-2.1.0.tgz",
+      "integrity": "sha512-WrWgdgwB6VP4uSqeUMo9nTY8VjZvWaXhUHXAmtvH7O8q4S2GVEu6k2XF++AeaWnzffdHCqVylKx505ty2uOZig==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.633.0",
-    "@miniben90/x-win": "^1.10.2",
+    "@miniben90/x-win": "^2.1.0",
     "@radix-ui/react-avatar": "^1.1.0",
     "@radix-ui/react-checkbox": "^1.1.1",
     "@radix-ui/react-label": "^2.1.0",


### PR DESCRIPTION
This pull request fix the issue #91 by upgrading the @miniben90/x-win package to version 2.1.0.

The current version (`1.10.2`) requires GLIBC 2.33, which is unavailable on many older Linux distributions, including Ubuntu 20.04. According to the [release notes](https://github.com/miniben-90/x-win/releases/tag/v2.0.0), version `2.0.0` of @miniben90/x-win reduces this requirement to GLIBC 2.18, making the app compatible with a wider range of platforms.  

Since this involves a major version bump, I reviewed the changelog and tested the application for any incompatibilities. I found no breaking changes, and the application functions as expected after the upgrade.  
