### PR TITLE
Add Roblox Studio plugin link

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -87,4 +87,10 @@ export const PLUGINS: {
     url: "https://addons.mozilla.org/en-US/firefox/addon/wakatimes/",
     type: "extension",
   },
+  {
+    execNames: ["RobloxStudioBeta.exe", "RobloxStudio.app"],
+    bundleIds: ["com.roblox.RobloxStudio"],
+    url: "https://wakatime.com/roblox-studio",
+    type: "plugin",
+  },
 ];


### PR DESCRIPTION
This change adds a link for the Roblox Studio plugin.

I wasn't able to get this to show up, unfortunately - I ran `npm run build` and then ran one of the installers. I'm not sure if there's a problem in my update process, or if I set up the bundle id or execNames incorrectly.

On Windows, I'm sure this is the process name, and on Mac, `RobloxStudio.app` is what I've seen gets used, but I'm not sure.

The bundle id I got from by opening the Mac `dmg` file in 7-zip, and I spotted `com.roblox.RobloxStudioInstaller`, so I'm assuming `roblox.RobloxStudio` is the correct bundle id.

Let me know if I have to change my build process to get this change showing up, or if there's something else we need to change 👍
