### PR TITLE
Less noisy diagnostics

### DIFF
--- a/electron/watchers/wakatime.ts
+++ b/electron/watchers/wakatime.ts
@@ -194,7 +194,6 @@ export class Wakatime {
         Logging.instance().log(
           `Error sending heartbeat: ${err}`,
           LogLevel.ERROR,
-          true,
         );
         this.tray?.displayBalloon({
           icon: nativeImage.createFromPath(


### PR DESCRIPTION
Prevents sending diags for unknown wakatime-cli errors.